### PR TITLE
top画面のコンポーネント分け

### DIFF
--- a/Heritage-View/src/app/app.component.html
+++ b/Heritage-View/src/app/app.component.html
@@ -1,1 +1,5 @@
+<mat-toolbar color="primary" class="toolbar">
+    <span>HeritageView</span>
+</mat-toolbar>
+
 <router-outlet></router-outlet>

--- a/Heritage-View/src/app/app.module.ts
+++ b/Heritage-View/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { TopComponent } from './pages/top/top.component';
+import { MenuCardsComponent } from './components/menu-cards/menu-cards.component';
 // material
 import { MatButtonModule } from '@angular/material/button';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -17,7 +18,8 @@ import { MatRadioModule } from '@angular/material/radio';
 @NgModule({
   declarations: [
     AppComponent,
-    TopComponent
+    TopComponent,
+    MenuCardsComponent
   ],
   imports: [
     BrowserModule,

--- a/Heritage-View/src/app/app.module.ts
+++ b/Heritage-View/src/app/app.module.ts
@@ -1,25 +1,26 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-// component
-import { AppRoutingModule } from './app-routing.module';
-import { AppComponent } from './app.component';
-import { TopComponent } from './pages/top/top.component';
-import { MenuCardsComponent } from './components/menu-cards/menu-cards.component';
 // material
 import { MatButtonModule } from '@angular/material/button';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatCardModule } from '@angular/material/card';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatRadioModule } from '@angular/material/radio';
-
+// component
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { TopComponent } from './pages/top/top.component';
+import { MenuCardsComponent } from './components/menu-cards/menu-cards.component';
+import { DifficultySetComponent } from './components/difficulty-set/difficulty-set.component';
 
 
 @NgModule({
   declarations: [
     AppComponent,
     TopComponent,
-    MenuCardsComponent
+    MenuCardsComponent,
+    DifficultySetComponent,
   ],
   imports: [
     BrowserModule,

--- a/Heritage-View/src/app/components/difficulty-set/difficulty-set.component.html
+++ b/Heritage-View/src/app/components/difficulty-set/difficulty-set.component.html
@@ -1,0 +1,7 @@
+<fieldset>
+    <legend>難易度変更</legend>
+    <button mat-raised-button  [color]="difficulty === 0 ? 'primary' : 'accent' "  (click)= "difficultyChange(0)">かんたん</button>
+    <button mat-raised-button class="normal-difficulty" [color]="difficulty === 1 ? 'primary' : 'accent' " (click)= "difficultyChange(1)"> ふつう</button>
+    <p>かんたん：  時間経過で次の問題に進みます</p>
+    <p>ふつう：  正解するまで次の問題に進みません</p>
+</fieldset>

--- a/Heritage-View/src/app/components/difficulty-set/difficulty-set.component.scss
+++ b/Heritage-View/src/app/components/difficulty-set/difficulty-set.component.scss
@@ -1,0 +1,3 @@
+.normal-difficulty {
+    margin-left: 1rem;
+}

--- a/Heritage-View/src/app/components/difficulty-set/difficulty-set.component.spec.ts
+++ b/Heritage-View/src/app/components/difficulty-set/difficulty-set.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DifficultySetComponent } from './difficulty-set.component';
+
+describe('DifficultySetComponent', () => {
+  let component: DifficultySetComponent;
+  let fixture: ComponentFixture<DifficultySetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DifficultySetComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DifficultySetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Heritage-View/src/app/components/difficulty-set/difficulty-set.component.ts
+++ b/Heritage-View/src/app/components/difficulty-set/difficulty-set.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+
+// 難易度 0: かんたん 1: ふつう
+type Difficulty = 0 | 1;
+
+@Component({
+  selector: 'app-difficulty-set',
+  templateUrl: './difficulty-set.component.html',
+  styleUrls: ['./difficulty-set.component.scss']
+})
+export class DifficultySetComponent implements OnInit {
+
+  difficulty: Difficulty = 1;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+  
+  difficultyChange(putValue: Difficulty): void {
+    this.difficulty = putValue;
+  }
+
+}

--- a/Heritage-View/src/app/components/menu-cards/menu-cards.component.html
+++ b/Heritage-View/src/app/components/menu-cards/menu-cards.component.html
@@ -1,0 +1,14 @@
+<mat-grid-list cols="3">
+    <mat-grid-tile *ngFor="let card of cards">
+
+        <button mat-button>
+            <mat-card class="card">
+                <div class="image-trim">
+                    <img mat-card-image src={{card.src}} alt="world image" class="card-img">
+                </div>
+                <mat-card-title>{{card.title}}</mat-card-title>
+            </mat-card>
+        </button>
+
+    </mat-grid-tile>
+</mat-grid-list>

--- a/Heritage-View/src/app/components/menu-cards/menu-cards.component.html
+++ b/Heritage-View/src/app/components/menu-cards/menu-cards.component.html
@@ -1,6 +1,5 @@
-<mat-grid-list cols="3">
-    <mat-grid-tile *ngFor="let card of cards">
-
+<div class="wrap">
+    <div class="item" *ngFor="let card of cards">
         <button mat-button>
             <mat-card class="card">
                 <div class="image-trim">
@@ -9,6 +8,5 @@
                 <mat-card-title>{{card.title}}</mat-card-title>
             </mat-card>
         </button>
-
-    </mat-grid-tile>
-</mat-grid-list>
+    </div>
+</div>

--- a/Heritage-View/src/app/components/menu-cards/menu-cards.component.scss
+++ b/Heritage-View/src/app/components/menu-cards/menu-cards.component.scss
@@ -1,0 +1,19 @@
+.card {
+    width: 22rem;
+
+    .image-trim {
+        position: relative;
+        overflow: hidden;
+        padding-top: 90%; /* 比率 */
+        
+    }
+      .image-trim img {
+        position: absolute;
+        top: 50%;
+        left: 55%;
+        transform: translate(-50%, -50%);
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+}

--- a/Heritage-View/src/app/components/menu-cards/menu-cards.component.scss
+++ b/Heritage-View/src/app/components/menu-cards/menu-cards.component.scss
@@ -17,3 +17,25 @@
         object-fit: cover;
     }
 }
+
+.wrap {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.item {
+    padding: 10px;
+    width: calc((100% - 30px * 2) / 3);
+}
+
+@media not all and (min-width: 960px) {
+    .item {
+        width: calc((100% - 30px * 2) / 2)
+    }
+}
+
+@media not all and (min-width: 600px) {
+    .item {
+        width: 100%
+    }
+}

--- a/Heritage-View/src/app/components/menu-cards/menu-cards.component.spec.ts
+++ b/Heritage-View/src/app/components/menu-cards/menu-cards.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MenuCardsComponent } from './menu-cards.component';
+
+describe('MenuCardsComponent', () => {
+  let component: MenuCardsComponent;
+  let fixture: ComponentFixture<MenuCardsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MenuCardsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MenuCardsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Heritage-View/src/app/components/menu-cards/menu-cards.component.ts
+++ b/Heritage-View/src/app/components/menu-cards/menu-cards.component.ts
@@ -6,12 +6,11 @@ export interface card {
 }
 
 @Component({
-  selector: 'app-top',
-  templateUrl: './top.component.html',
-  styleUrls: ['./top.component.scss']
+  selector: 'app-menu-cards',
+  templateUrl: './menu-cards.component.html',
+  styleUrls: ['./menu-cards.component.scss']
 })
-
-export class TopComponent implements OnInit {
+export class MenuCardsComponent implements OnInit {
 
   cards: card[] = [
     {title: '全世界', src: '/assets/cardImages/全般.jpeg'},
@@ -22,8 +21,10 @@ export class TopComponent implements OnInit {
     {title: '南アメリカ/オセアニア', src: '/assets/cardImages/南アメリカ.jpeg'},
   ]
 
+
   constructor() { }
 
   ngOnInit(): void {
   }
+
 }

--- a/Heritage-View/src/app/pages/top/top.component.html
+++ b/Heritage-View/src/app/pages/top/top.component.html
@@ -16,22 +16,7 @@
     </div>
     
     <p class="margin-left explanatory">選択された地域の世界遺産が計５問出題されます</p>
-    
-    <mat-grid-list cols="3">
-        <mat-grid-tile *ngFor="let card of cards">
-    
-            <button mat-button>
-                <mat-card class="card">
-                    <div class="image-trim">
-                        <img mat-card-image src={{card.src}} alt="world image" class="card-img">
-                    </div>
-                    <mat-card-title>{{card.title}}</mat-card-title>
-                </mat-card>
-            </button>
-           
-    
-        </mat-grid-tile>
-    </mat-grid-list>
 
+    <app-menu-cards></app-menu-cards>
 </div>
 

--- a/Heritage-View/src/app/pages/top/top.component.html
+++ b/Heritage-View/src/app/pages/top/top.component.html
@@ -1,16 +1,6 @@
-<mat-toolbar color="primary" class="toolbar">
-    <span>HeritageView</span>
-</mat-toolbar>
-
 <div class="content">
     <div class="top-container">
-            <fieldset class="margin-left">
-                <legend>難易度変更</legend>
-                <button mat-raised-button  color="primary">かんたん</button>
-                <button mat-raised-button class="normal-difficulty" color="primary">ふつう</button>
-                <p>かんたん：  時間経過で次の問題に進みます</p>
-                <p>ふつう：  正解するまで次の問題に進みません</p>
-            </fieldset>
+            <app-difficulty-set class="margin-left"></app-difficulty-set>
 
             <button mat-raised-button class="how-to-play" color="primary">遊び方</button>
     </div>

--- a/Heritage-View/src/app/pages/top/top.component.scss
+++ b/Heritage-View/src/app/pages/top/top.component.scss
@@ -33,24 +33,4 @@
     .explanatory {
         font-size: 1.3em;
     }
-
-    .card {
-        width: 22rem;
-
-        .image-trim {
-            position: relative;
-            overflow: hidden;
-            padding-top: 90%; /* 比率 */
-            
-          }
-          .image-trim img {
-            position: absolute;
-            top: 50%;
-            left: 55%;
-            transform: translate(-50%, -50%);
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-          }
-    }
 }

--- a/Heritage-View/src/app/pages/top/top.component.scss
+++ b/Heritage-View/src/app/pages/top/top.component.scss
@@ -15,10 +15,6 @@
             width: 10rem;
             height: 3rem;
         }
-    
-        .normal-difficulty {
-            margin-left: 1rem;
-        }
     }
 
     .margin-left {

--- a/Heritage-View/src/styles.scss
+++ b/Heritage-View/src/styles.scss
@@ -3,7 +3,7 @@
 @include mat.core();
 
 $my-primary: mat.define-palette(mat.$teal-palette, A200);
-$my-accent: mat.define-palette(mat.$pink-palette, A200, A100, A400);
+$my-accent: mat.define-palette(mat.$grey-palette, 300);
 
 $my-theme: mat.define-light-theme((
  color: (


### PR DESCRIPTION
- 難易度選択、モード選択をコンポーネント分け
-  ヘッダーをappに移動
-  モード選択をgridからflexに変更